### PR TITLE
Updating gitignore to work how we expected

### DIFF
--- a/Source-Code/Drone2/.gitignore
+++ b/Source-Code/Drone2/.gitignore
@@ -1,10 +1,16 @@
 # Ignore all files under impl* except verilog source files
 
 /*
-!impl*/source/*.v
-!impl*/source/*I2C_EFB_WB*
+!/impl*
+/impl*/*
+!/impl*/source
+/impl*/source/*
+!/impl*/source/*.v
+!/impl*/source/*I2C_EFB_WB*
 !Drone2.lpf
 !Drone2.ldf
 !Drone21.sty
 !project_setup.tcl
 !.editorconfig
+!.gitignore
+


### PR DESCRIPTION
It seems that you have to ignore all paths leading up to the path
where you want to include files.  Kind of alike a recursive ignore
all then unignore what you need in the next level and then ignore
all again and then unignore in that level ... ja ja ja.

Signed-off-by: bcreeley <bcreeley@pdx.edu>