### PR TITLE
Make onboard debug leds work for more things

### DIFF
--- a/Source-Code/Drone2/Drone2.lpf
+++ b/Source-Code/Drone2/Drone2.lpf
@@ -41,3 +41,4 @@ LOCATE COMP "motor_1_pwm" SITE "P9" ;
 LOCATE COMP "motor_2_pwm" SITE "M8" ;
 LOCATE COMP "motor_3_pwm" SITE "T9" ;
 LOCATE COMP "motor_4_pwm" SITE "N9" ;
+LOCATE COMP "debug_leds_receiver_throttle_n" SITE "N2" ;


### PR DESCRIPTION
Use the flip switches to enable multiple debug output choices
to the onboard debug leds.

This needs to be tested still and the following are the current
uses.

reset - 1110 (flip switch position)
display receiver throttle output - 1101 (flip switch position)
display imu debug output - default (all other flip switch positions)