### PR TITLE
Change clock for motor_mixer module to be us_clk instead of sys_clk

### DIFF
--- a/Source-Code/Drone2/impl1/source/drone2.v
+++ b/Source-Code/Drone2/impl1/source/drone2.v
@@ -218,7 +218,7 @@ module drone2 (
 		.roll_rate(roll_target_rate),
 		.pitch_rate(pitch_target_rate),
 
-		.sys_clk(sys_clk),
+		.sys_clk(us_clk),
 		.rst_n(resetn));
 
 	pwm_generator pwm_generator (


### PR DESCRIPTION
As I was updating the Level 1 Block Diagram for drone2.v I noticed
that the only two modules using the sys_clk were the IMU and the
motor_mixer. The IMU will have synchronization, but it makes sense
to just run the motor_mixer at the same clock rate as all the other
modules.

This is not tested, but it should not break anything. Regardless
it needs to be loaded on to the drone platform and see if we notice
any improvement (i.e. no output pauses).