### PR TITLE
Change which bits we are sending to the pwm_generator from the MM

### DIFF
--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -56,7 +56,7 @@ module angle_controller (
 	// TODO: Use decimal values instead to avoid having to comment
 	// rate limits (16-bit, 2's complement, 12-bit integer, 4-bit fractional)
 	localparam signed
-		THROTTLE_MAX = 16'h0fc0, // 60
+		THROTTLE_MAX = 16'h0fa0, // 250
 		YAW_MAX =      16'h0190, // 25
 		YAW_MIN =      16'hfe70, // -25
 		PITCH_MAX =    16'h0190, // 25
@@ -175,9 +175,7 @@ module angle_controller (
 					complete_signal <= 1'b0;
 					active_signal <= 1'b1;
 
-					// TODO Change these value ranges!
-					// input value mapped from  0 - 250 to 0 - 62.5
-					mapped_throttle <= {6'b000000, latched_throttle, 2'b00}; // ???
+					mapped_throttle <= {4'h0, latched_throttle, 4'h0};
 					// input values mapped from 0 - 250 to -31.25 - 31.25
 					mapped_yaw <= $signed({7'b0000000, latched_yaw, 1'b0}) - $signed(16'd250);
 					// roll value from IMU is flipped, add instead of subtract (do this in bfc too?)

--- a/Source-Code/Drone2/impl1/source/common_defines.v
+++ b/Source-Code/Drone2/impl1/source/common_defines.v
@@ -63,8 +63,8 @@
  ************************************************************/
 
 //	Min and Max boundary values for to send to ESC's
-`define MOTOR_VAL_MIN					16'h0002
-`define MOTOR_VAL_MAX					16'h03E8
+`define MOTOR_VAL_MIN					16'h0020
+`define MOTOR_VAL_MAX					16'h0FA0
 
 //	Bias to add as a buffer to the motor equation
 `define	MOTOR_1_RATE_BIAS				 	$signed(16'h0000)

--- a/Source-Code/Drone2/impl1/source/motor_mixer.v
+++ b/Source-Code/Drone2/impl1/source/motor_mixer.v
@@ -246,10 +246,10 @@ module motor_mixer (
 
 				end
 				STATE_SEND_OUTPUT: 	begin	//	Reduce the motor_rates to 8 bit for pwm_generator use
-					motor_1_rate		<= motor_1_temp[9:2];
-					motor_2_rate		<= motor_2_temp[9:2];
-					motor_3_rate		<= motor_3_temp[9:2];
-					motor_4_rate		<= motor_4_temp[9:2];
+					motor_1_rate		<= motor_1_temp[11:4];
+					motor_2_rate		<= motor_2_temp[11:4];
+					motor_3_rate		<= motor_3_temp[11:4];
+					motor_4_rate		<= motor_4_temp[11:4];
 					motor_mixer_state 	<= STATE_SCALE_RATES;
 				end
 				default begin


### PR DESCRIPTION
Currently we are sending bits 9:2 to the pwm_generator, but this
is including an integer and fractional portion. We are currently extracting
these bits from a 16 bit s11.4 2's complement fixed point value. Instead
extract bits 11:4 so we are only extracting the integer bit.