### PR TITLE
Fix assignment under multiple edges AC/BFC

### DIFF
--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -96,7 +96,7 @@ module angle_controller (
 	reg start_flag = 1'b0;
 
 	// latch start signal
-	always @(posedge start_signal or posedge us_clk or negedge resetn) begin
+	always @(posedge us_clk or negedge resetn) begin
 		if(!resetn)
 			start_flag <= 1'b0;
 		else if(start_signal && !start_flag)

--- a/Source-Code/Drone2/impl1/source/body_frame_controller.v
+++ b/Source-Code/Drone2/impl1/source/body_frame_controller.v
@@ -124,7 +124,7 @@ module body_frame_controller (
 	assign DEBUG_WIRE = (!resetn) ? 16'h0 : DEBUG_WIRE_PITCH;
 
 	// latch start signal and target/actual rotational angles
-	always @(posedge start_signal or posedge us_clk or negedge resetn) begin
+	always @(posedge us_clk or negedge resetn) begin
 		if(!resetn) begin
 			start_flag					<= 1'b0;
 			


### PR DESCRIPTION
We were getting a warning using the start_signal as an edge
triggered signal. Some how this was causing multiplication
by random values (i.e. 2) not work on the drone. Removing
the start_signal from the list seemingly fixes this issue.