### PR TITLE
60ms WD and 10S recovery timer

### DIFF
--- a/Source-Code/Drone2/impl1/source/i2c_module_top.v
+++ b/Source-Code/Drone2/impl1/source/i2c_module_top.v
@@ -46,7 +46,7 @@ module i2c_module(
 	reg  [(`I2C_STATE_BITS-1):0]next_i2c_cmd_state; //  Module FSM NEXT state
 	reg  [11:0]count_us;                            //  Count from 0 to value determined by clock rate, used to generate 1us delay trigger
 	reg  clear_waiting_us;                          //  Start multi-us counter from pre-set start value
-	reg  [23:0]count_wd_delay ;                     //  Countdown watchdog timer for hardware reset
+	reg  [31:0]count_wd_delay ;                     //  Countdown watchdog timer for hardware reset
 	reg  wd_event_active;                           //  The current WD event state, active indicates a watchdog fault
 	reg  clear_watchdog;                            //  Reset watchdog to max value
 	wire irq1_out, irq2_out;                        //  IRQ output from EFB i2c modules
@@ -122,17 +122,17 @@ module i2c_module(
 			count_us       <= count_us;
 	end
 
-	//  Generates a 30 ms watchdog timer
+	//  Generates a 60 ms watchdog timer
 	always@(posedge sys_clk, negedge rstn) begin
 		if(~rstn) begin
-			count_wd_delay  <= 24'hFFFFFF;
+			count_wd_delay  <= 32'hFFFFFFFF;
 			wd_event_active <= `FALSE;
 		end
 		else if ( (clear_watchdog  == `CLEAR_WD_TIMER) || (~rstn_imu) ) begin //If IMU is being rest keep WD from running
-			count_wd_delay <= (`WAIT_MS_DIVIDER*8'd30);
+			count_wd_delay <= (`WAIT_MS_DIVIDER*60);
 			wd_event_active <= `FALSE;
 		end
-		else if( count_wd_delay != 24'hFFFFFF  ) begin
+		else if( count_wd_delay != 32'hFFFFFFFF  ) begin
 			count_wd_delay <= (count_wd_delay - 1'b1);
 			wd_event_active <= `FALSE;
 		end

--- a/Source-Code/testing_files/i2c_sim/i2c_module_top-SIM.v
+++ b/Source-Code/testing_files/i2c_sim/i2c_module_top-SIM.v
@@ -42,7 +42,7 @@ module i2c_module(
 	reg  [(`I2C_STATE_BITS-1):0]next_i2c_cmd_state; //  Module FSM NEXT state
 	reg  [11:0]count_us;                            //  Count from 0 to value determined by clock rate, used to generate 1us delay trigger
 	reg  clear_waiting_us;                          //  Start multi-us counter from pre-set start value
-	reg  [23:0]count_wd_delay ;                     //  Countdown watchdog timer for hardware reset
+	reg  [31:0]count_wd_delay ;                     //  Countdown watchdog timer for hardware reset
 	reg  wd_event_active;                           //  The current WD event state, active indicates a watchdog fault
 	reg  clear_watchdog;                            //  Reset watchdog to max value
 	reg  irq1_out, irq2_out;                        //  IRQ output from EFB i2c modules
@@ -103,17 +103,17 @@ module i2c_module(
 			count_us       <= count_us;
 	end
 
-	//  Generates a 30 ms watchdog timer
+	//  Generates a 60 ms watchdog timer
 	always@(posedge sys_clk, negedge rstn) begin
 		if(~rstn) begin
-			count_wd_delay  <= 24'hFFFFFF;
+			count_wd_delay  <= 32'hFFFFFFFF;
 			wd_event_active <= `FALSE;
 		end
 		else if ( (clear_watchdog  == `CLEAR_WD_TIMER) || (~rstn_imu) ) begin //If IMU is being rest keep WD from running
-			count_wd_delay <= (`WAIT_MS_DIVIDER*8'd30);
+			count_wd_delay <= (`WAIT_MS_DIVIDER*60);
 			wd_event_active <= `FALSE;
 		end
-		else if( count_wd_delay != 24'hFFFFFF  ) begin
+		else if( count_wd_delay != 32'hFFFFFFFF  ) begin
 			count_wd_delay <= (count_wd_delay - 1'b1);
 			wd_event_active <= `FALSE;
 		end


### PR DESCRIPTION
Lengthen watchdog timer and increase bitwidths to handle larger timers. 10 second recovery time is not here. That time is a module parameter set by the testbench. The default of 650 ms is unchanged 