### PR TITLE
Expand all calcualtion and intermediate registers to 32bit for overfl…

### DIFF
--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -87,7 +87,7 @@ module angle_controller (
 	// Mapping input Padding Zeros
 	localparam signed
 		END_PAD				=  2'b0,
-		FRONT_PAD 			= 24'b0,
+		FRONT_PAD 			= 22'b0,
 		THROTTLE_F_PAD		= 20'b0,
 		THROTTLE_R_PAD		=  4'b0;
 

--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -65,14 +65,14 @@ module angle_controller (
 	// scale factors (16-bit, 2's complement, 12-bit integer, 4-bit fractional)
 	// Multiplier Scaler Values
 	localparam signed [`OPS_BIT_WIDTH-1:0]
-		YAW_SCALE_MULT 		= 1,
+		YAW_SCALE_MULT 		= 48,
 		ROLL_SCALE_MULT 	= 36,
 		PITCH_SCALE_MULT 	= 32,
 		THROTTLE_SCALE_MULT	= 1;
 	
 	//Divisor Shift Values
 	localparam signed [`SHIFT_OP_BIT_WIDTH-1:0]	
-		YAW_SCALE_DIV 		= 0,
+		YAW_SCALE_DIV 		= 4,
 		PITCH_SCALE_DIV 	= 4,
 		ROLL_SCALE_DIV	 	= 4,
 		THROTTLE_SCALE_DIV	= 0;

--- a/Source-Code/Drone2/impl1/source/body_frame_controller.v
+++ b/Source-Code/Drone2/impl1/source/body_frame_controller.v
@@ -94,7 +94,7 @@ module body_frame_controller (
 	 */	
 	 // YAW CONTROL PARAMS
 	 localparam signed [`OPS_BIT_WIDTH-1:0]
-		YAW_K_P			= 51, // d48 no oscillating -> d56 oscillates
+		YAW_K_P			= 48, // d48 no oscillating -> d56 oscillates
 		YAW_K_I			= 0,
 		YAW_K_D			= 5;
 	localparam signed [`SHIFT_OP_BIT_WIDTH-1:0]

--- a/Source-Code/Drone2/impl1/source/body_frame_controller.v
+++ b/Source-Code/Drone2/impl1/source/body_frame_controller.v
@@ -79,40 +79,48 @@ module body_frame_controller (
 		STATE_COMPLETE = 4'b1000;
 
 	// PID controller rate limiting values
-	localparam signed 
-		ROLL_RATE_MIN  = -16'd4000,
-		ROLL_RATE_MAX  =  16'd4000,
-		PITCH_RATE_MIN = -16'd4000,
-		PITCH_RATE_MAX =  16'd4000,
-		YAW_RATE_MIN   = -16'd4000,
-		YAW_RATE_MAX   =  16'd4000;
+	localparam signed [`OPS_BIT_WIDTH-1:0]
+		ROLL_RATE_MIN  = -250 << `FIXED_POINT_SHIFT,
+		ROLL_RATE_MAX  =  250 << `FIXED_POINT_SHIFT,
+		PITCH_RATE_MIN = -250 << `FIXED_POINT_SHIFT,
+		PITCH_RATE_MAX =  250 << `FIXED_POINT_SHIFT,
+		YAW_RATE_MIN   = -250 << `FIXED_POINT_SHIFT,
+		YAW_RATE_MAX   =  250 << `FIXED_POINT_SHIFT;
 
 	/* PID controller proportional/integral/derivative constant values.
 	 * These are determined by first multiplying the value by the specific
 	 * K_* term and then shifting it using the K_*_SHIFT value.
 	 * Example: value = (value * ROLL_K_P) >>> ROLL_K_P_SHIFT;
 	 */	
-	 localparam signed // YAW CONTROL PARAMS
-		YAW_K_P			= 16'h001F,
-		YAW_K_P_SHIFT	= 4'h4,
-		YAW_K_I			= 16'h0000,
-		YAW_K_I_SHIFT	= 4'h4,
-		YAW_K_D			= 16'h0004,
-		YAW_K_D_SHIFT	= 4'h4;
-	localparam signed // ROLL CONTROL PARAMS
-		ROLL_K_P		= 16'h0004,
-		ROLL_K_P_SHIFT	= 4'h4,
-		ROLL_K_I		= 16'h0000,
-		ROLL_K_I_SHIFT	= 4'h4,
-		ROLL_K_D		= 16'h0001,
-		ROLL_K_D_SHIFT	= 4'h4;
-	localparam signed // PITCH CONTROL PARAMS
-		PITCH_K_P		= 16'h0004,
-		PITCH_K_P_SHIFT = 4'h4,
-		PITCH_K_I		= 16'h0000,
-		PITCH_K_I_SHIFT = 4'h4,
-		PITCH_K_D		= 16'h0001,
-		PITCH_K_D_SHIFT = 4'h4;
+	 // YAW CONTROL PARAMS
+	 localparam signed [`OPS_BIT_WIDTH-1:0]
+		YAW_K_P			= 51, // d48 no oscillating -> d56 oscillates
+		YAW_K_I			= 0,
+		YAW_K_D			= 5;
+	localparam signed [`SHIFT_OP_BIT_WIDTH-1:0]
+		YAW_K_P_SHIFT	= 4,
+		YAW_K_I_SHIFT	= 4,
+		YAW_K_D_SHIFT	= 4;
+		
+	// ROLL CONTROL PARAMS
+	localparam signed [`OPS_BIT_WIDTH-1:0]
+		ROLL_K_P		= 5,
+		ROLL_K_I		= 3,
+		ROLL_K_D		= 4;
+	localparam signed [`SHIFT_OP_BIT_WIDTH-1:0]
+		ROLL_K_P_SHIFT	= 4,
+		ROLL_K_I_SHIFT	= 4,
+		ROLL_K_D_SHIFT	= 4;
+		
+	// PITCH CONTROL PARAMS
+	localparam signed [`OPS_BIT_WIDTH-1:0]
+		PITCH_K_P		= 5,
+		PITCH_K_I		= 3,
+		PITCH_K_D		= 4;
+	localparam signed [`SHIFT_OP_BIT_WIDTH-1:0]
+		PITCH_K_P_SHIFT = 4,
+		PITCH_K_I_SHIFT = 4,
+		PITCH_K_D_SHIFT = 4;
 
 	// state variables
 	reg [STATE_BIT_WIDTH-1:0] state, next_state;

--- a/Source-Code/Drone2/impl1/source/common_defines.v
+++ b/Source-Code/Drone2/impl1/source/common_defines.v
@@ -28,6 +28,13 @@
 // Mathematical bit addition
 `define ONE		1'b1
 
+// MAX MIN fixed point shift in decimal
+`define FIXED_POINT_SHIFT		4'sd4
+`define OPS_BIT_WIDTH			7'd32
+`define SHIFT_OP_BIT_WIDTH		3'd4
+`define	BITS_EXTRACT			6'd16
+`define PADDING_ZEROS 			16'd0
+
 //  A byte of all zeros
 `define BYTE_ALL_ZERO           8'sh00
 `define ALL_ZERO_2BYTE          16'sh0000

--- a/Source-Code/Drone2/impl1/source/motor_mixer.v
+++ b/Source-Code/Drone2/impl1/source/motor_mixer.v
@@ -79,17 +79,19 @@ module motor_mixer (
 		STATE_BOUNDARY_CHECK	= 2,
 		STATE_SEND_OUTPUT		= 3;
 	reg [1:0] motor_mixer_state;
-
+	
 	//	Bias to add as a buffer to the motor equation
-	localparam signed 
-		MOTOR_1_RATE_BIAS		= 16'd0,
-		MOTOR_2_RATE_BIAS		= 16'd0,
-		MOTOR_3_RATE_BIAS		= 16'd0,
-		MOTOR_4_RATE_BIAS		= 16'd0;
+	localparam BIAS_BIT_WIDTH = 6'd16;
+	localparam signed [BIAS_BIT_WIDTH-1:0]
+		MOTOR_1_RATE_BIAS		= 0,
+		MOTOR_2_RATE_BIAS		= 0,
+		MOTOR_3_RATE_BIAS		= 0,
+		MOTOR_4_RATE_BIAS		= 0;
 
 	//	Scaler to set proportions of yaw, roll, and pitch
 	//  Shift to change impact of roll, pitch, and yaw
-	localparam
+	localparam SCALER_BIT_WIDTH = 1'd1;
+	localparam [SCALER_BIT_WIDTH-1:0]
 		MOTOR_RATE_YAW_SCALER 	= 1'd1,
 		MOTOR_RATE_ROLL_SCALER	= 1'd1,
 		MOTOR_RATE_PITCH_SCALER	= 1'd1;

--- a/Source-Code/Drone2/impl1/source/pid.v
+++ b/Source-Code/Drone2/impl1/source/pid.v
@@ -18,56 +18,58 @@
  `timescale 1ns / 1ns
  `include "common_defines.v"
 
- module pid #(parameter signed RATE_MIN = 16'h8000,
-	 		  parameter signed RATE_MAX = 16'h7FFF,
+ module pid #(parameter signed [`OPS_BIT_WIDTH-1:0] RATE_MIN = 32'h80000000,
+	 		  parameter signed [`OPS_BIT_WIDTH-1:0] RATE_MAX = 32'h7FFFFFFF,
+			  parameter signed [`OPS_BIT_WIDTH-1:0] K_P = 1,
+			  parameter signed [`OPS_BIT_WIDTH-1:0] K_I = 1,
+			  parameter signed [`OPS_BIT_WIDTH-1:0] K_D = 1,
 			  parameter signed K_P_SHIFT = 4'h4,
 			  parameter signed K_I_SHIFT = 4'h4,
-			  parameter signed K_D_SHIFT = 4'h4,
-			  parameter signed K_P = 16'h0001,
-			  parameter signed K_I = 16'h0001,
-			  parameter signed K_D = 16'h0001)
+			  parameter signed K_D_SHIFT = 4'h4)
  			 (output reg pid_complete,
 			  output reg pid_active,
-			  output reg signed [`PID_RATE_BIT_WIDTH-1:0] rate_out,
-			  output wire [`DEBUG_WIRE_BIT_WIDTH-1:0] 	  DEBUG_WIRE, /*DEBUG LEDs*/
-			  input wire signed [`RATE_BIT_WIDTH-1:0] 	  angle_error,
-			  input wire signed [`RATE_BIT_WIDTH-1:0] 	  target_rotation,
- 			  input wire signed [`IMU_VAL_BIT_WIDTH-1:0]  actual_rotation,
-			  input wire start_flag,
-			  input wire wait_flag,
-			  input wire resetn,
-			  input wire us_clk);
+			  output reg signed  [`PID_RATE_BIT_WIDTH-1:0] 	rate_out,
+			  output wire 		 [`DEBUG_WIRE_BIT_WIDTH-1:0]DEBUG_WIRE, /*DEBUG LEDs*/
+			  input  wire signed [`RATE_BIT_WIDTH-1:0] 	  	angle_error,
+			  input  wire signed [`RATE_BIT_WIDTH-1:0] 	  	target_rotation,
+ 			  input  wire signed [`IMU_VAL_BIT_WIDTH-1:0]  	actual_rotation,
+			  input  wire start_flag,
+			  input  wire wait_flag,
+			  input  wire resetn,
+			  input  wire us_clk);
 
 	// working registers
-	reg signed [`RATE_BIT_WIDTH-1:0] 
+	reg signed [`OPS_BIT_WIDTH-1:0]
 		error_change, 
 		rotation_total,
 		rotation_error, 
+		angle_err_temp,
+		target_rot_temp,
+		actual_rot_temp,
 		prev_rotation_error,
 		scaled_rotation,
 		rotation_integral,
 		rotation_derivative,
 		rotation_proportional;
-
-	reg signed [`RATE_BIT_WIDTH-1:0]
-		latched_angle_error,
-		latched_target_rotation, 
-		latched_actual_rotation;
-
+	
+	// PADDING AND EXTEND SIGN BIT TO 32 BITS
+	localparam SHIFT_TO_LSB = 5'd16;
+	
 	// state names
-	localparam
-		STATE_WAIT     = 6'b000001,
-		STATE_CALC1    = 6'b000010,
-		STATE_CALC2    = 6'b000100,
-		STATE_CALC3    = 6'b001000,
-		STATE_CALC4    = 6'b010000,
-		STATE_COMPLETE = 6'b100000;
-
+	localparam STATE_BIT_WIDTH = 7;
+	localparam [STATE_BIT_WIDTH-1:0]
+		STATE_WAIT     		= 7'b0000001,
+		STATE_EXTEND_32BIT	= 7'b0000010,
+		STATE_CALC1    		= 7'b0000100,
+		STATE_CALC2    		= 7'b0001000,
+		STATE_CALC3    		= 7'b0010000,
+		STATE_CALC4    		= 7'b0100000,
+		STATE_COMPLETE 		= 7'b1000000;
 	// state variables
-	reg [5:0] state, next_state;
+	reg [STATE_BIT_WIDTH-1:0] state, next_state;
 
 	//Debug wire assign to monitor values on 16 led daughter board
-	assign DEBUG_WIRE = rotation_total;
+	assign DEBUG_WIRE = rotation_total[15:0];
 
 	// update state
 	always @(posedge us_clk or negedge resetn) begin
@@ -90,12 +92,19 @@
 					pid_active				<= `FALSE;
 					pid_complete			<= `TRUE;
 				end
+				STATE_EXTEND_32BIT: begin
+					pid_active 				<= `TRUE;
+					pid_complete 			<= `FALSE;
+					angle_err_temp			<= $signed({angle_error, 	 `PADDING_ZEROS}) >>> SHIFT_TO_LSB;
+					target_rot_temp			<= $signed({target_rotation, `PADDING_ZEROS}) >>> SHIFT_TO_LSB;
+					actual_rot_temp			<= $signed({actual_rotation, `PADDING_ZEROS}) >>> SHIFT_TO_LSB;
+				end
 				STATE_CALC1: begin
 					pid_active 				<= `TRUE;
 					pid_complete 			<= `FALSE;
 					prev_rotation_error 	<= rotation_error;
-					rotation_error 			<= target_rotation - actual_rotation;
-					rotation_integral 		<= (K_I * angle_error) >>> K_I_SHIFT;
+					rotation_error 			<= target_rot_temp - actual_rot_temp;
+					rotation_integral 		<= (K_I * angle_err_temp) >>> K_I_SHIFT;
 				end
 				STATE_CALC2: begin
 					pid_active 				<= `TRUE;
@@ -117,11 +126,11 @@
 					pid_active 				<= `TRUE;
 					pid_complete 			<= `TRUE;
 					if(rotation_total < RATE_MIN)
-						rate_out 			<= RATE_MIN;
+						rate_out 			<= RATE_MIN[`BITS_EXTRACT-1:0];
 					else if(rotation_total > RATE_MAX)
-						rate_out 			<= RATE_MAX;
+						rate_out 			<= RATE_MAX[`BITS_EXTRACT-1:0];
 					else
-						rate_out 			<= rotation_total;
+						rate_out 			<= rotation_total[`BITS_EXTRACT-1:0];
 				end
 				default: begin
 					pid_active 				<= `FALSE;
@@ -141,9 +150,12 @@
 			case(state)
 				STATE_WAIT: begin
 					if(start_flag)
-						next_state 	= STATE_CALC1;
+						next_state 	= STATE_EXTEND_32BIT;
 					else
 						next_state	= STATE_WAIT;
+				end
+				STATE_EXTEND_32BIT: begin
+					next_state		= STATE_CALC1;
 				end
 				STATE_CALC1: begin
 				   next_state		= STATE_CALC2;
@@ -170,4 +182,3 @@
 		end
 	end
 endmodule
-


### PR DESCRIPTION
extend AC and PID math to 32bit due to intermediate registers sized per used values and we get overflow easily for yaw. Also Cleaned up localparams and removed Yaw scaling in AC. 