### PR TITLE
Introducing: Acrobatic Mode

### DIFF
--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -56,12 +56,12 @@ module angle_controller (
 	// rate limits (16-bit, 2's complement, 12-bit integer, 4-bit fractional)
 	localparam signed [`OPS_BIT_WIDTH-1:0]
 		THROTTLE_MAX 	=  250 << `FIXED_POINT_SHIFT,
-		YAW_MAX 		=  100 << `FIXED_POINT_SHIFT,
-		YAW_MIN 		= -100 << `FIXED_POINT_SHIFT,
-		PITCH_MAX 		=  100 << `FIXED_POINT_SHIFT,
-		PITCH_MIN 		= -100 << `FIXED_POINT_SHIFT,
-		ROLL_MAX		=  100 << `FIXED_POINT_SHIFT,
-		ROLL_MIN		= -100 << `FIXED_POINT_SHIFT;
+		YAW_MAX 		=  200 << `FIXED_POINT_SHIFT,
+		YAW_MIN 		= -200 << `FIXED_POINT_SHIFT,
+		PITCH_MAX 		=  200 << `FIXED_POINT_SHIFT,
+		PITCH_MIN 		= -200 << `FIXED_POINT_SHIFT,
+		ROLL_MAX		=  200 << `FIXED_POINT_SHIFT,
+		ROLL_MIN		= -200 << `FIXED_POINT_SHIFT;
 
 
 	// Mapping input range to other

--- a/Source-Code/Drone2/impl1/source/angle_controller.v
+++ b/Source-Code/Drone2/impl1/source/angle_controller.v
@@ -174,8 +174,8 @@ module angle_controller (
 					mapped_throttle 		<= {THROTTLE_F_PAD, latched_throttle, THROTTLE_R_PAD};
 					// input values mapped from 0 - 250 to -31.25 - 31.25
 					mapped_yaw 				<= $signed({FRONT_PAD, latched_yaw,   END_PAD}) - MAPPING_SUBS;
-					mapped_roll 			<= $signed({FRONT_PAD, latched_roll,  END_PAD}) - MAPPING_SUBS + roll_actual; // roll value from IMU is flipped, add instead of subtract
-					mapped_pitch 			<= $signed({FRONT_PAD, latched_pitch, END_PAD}) - MAPPING_SUBS - pitch_actual;
+					mapped_roll 			<= ($signed({FRONT_PAD, latched_roll,  END_PAD}) - MAPPING_SUBS)*16'sd2 + roll_actual; // roll value from IMU is flipped, add instead of subtract
+					mapped_pitch 			<= ($signed({FRONT_PAD, latched_pitch, END_PAD}) - MAPPING_SUBS)*16'sd2 - pitch_actual;
 				end
 				STATE_SCALING: begin
 					complete_signal 		<= `FALSE;


### PR DESCRIPTION
I noticed that sometimes it felt like the drone didn't have enough stick input for pitch and roll. It couldn't tilt enough to compensate for external inputs (Wind, IMU out of level). This commit doubles the pitch/roll limits and multiplies the scaled input value by 2. This gives a much more responsive and sporty drone. It's possible that I just needed to increase the limit values for pitch and roll to allow enough stick input to overcome external inputs. This small change works quite well, so two birds with one stone.